### PR TITLE
feat: 오류 코드에 대한 레거시 정리, 상태 코드 재정의

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:11.0.14
 
-EXPOSE 2021
+EXPOSE 50000
 
 ARG JAR_FILE=build/libs/*.jar
 

--- a/src/main/java/com/danplay/server/base/exception/DanplayException.java
+++ b/src/main/java/com/danplay/server/base/exception/DanplayException.java
@@ -1,6 +1,7 @@
 package com.danplay.server.base.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class DanplayException extends RuntimeException {
@@ -8,10 +9,12 @@ public class DanplayException extends RuntimeException {
     private final ExceptionCodeAndDetails codeAndMessage = ExceptionCodeAndDetails
             .findByClass(this.getClass());
 
+    private HttpStatus status;
     private String code;
     private String message;
 
     public DanplayException() {
+        this.status = codeAndMessage.getStatus();
         this.code = codeAndMessage.getCode();
         this.message = codeAndMessage.getMessage();
     }

--- a/src/main/java/com/danplay/server/base/exception/ExceptionCodeAndDetails.java
+++ b/src/main/java/com/danplay/server/base/exception/ExceptionCodeAndDetails.java
@@ -3,12 +3,11 @@ package com.danplay.server.base.exception;
 import com.danplay.server.mail.exception.DuplicateMailException;
 import com.danplay.server.user.exception.InvalidFindPasswordException;
 import com.danplay.server.mail.exception.InvalidMailCodeException;
-import com.danplay.server.mail.exception.InvalidMailTypeException;
-import com.danplay.server.user.exception.DuplicateLoginIdException;
 import com.danplay.server.user.exception.InvalidPasswordException;
 import com.danplay.server.user.exception.NonExistMailUserException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.Arrays;
@@ -16,15 +15,15 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum ExceptionCodeAndDetails {
-    NOT_FOUND_API("0002", "해당 경로에 대한 응답 API를 찾을 수 없습니다", NoHandlerFoundException.class),
-    INVALID_REQUEST_TYPE("0003", "요청한 API에서 요구하는 형식에 맞지 않는 필드가 존재합니다", InvalidRequestTypeException.class),
-    INVALID_MAIL_TYPE("1001", "형식에 맞지 않는 메일입니다", InvalidMailTypeException.class),
-    DUPLICATE_USER("1002", "Danplay 서비스에 가입되어있는 계정입니다", DuplicateMailException.class),
-    INVALID_MAIL_CODE("1003", "유효하지 않은 인증코드 입니다", InvalidMailCodeException.class),
-    NON_EXIST_MAIL_USER("2001", "존재하지 않는 계정입니다", NonExistMailUserException.class),
-    INVALID_PASSWORD("2002","비밀번호가 일치하지 않습니다", InvalidPasswordException.class),
-    INVALID_FIND_PASSWORD("2003", "서버에 저장된 사용자 정보와 일치하지 않습니다", InvalidFindPasswordException.class);
+    NOT_FOUND_API(HttpStatus.NOT_FOUND, "0002", "해당 경로에 대한 응답 API를 찾을 수 없습니다", NoHandlerFoundException.class),
+    INVALID_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "0003", "요청한 API에서 요구하는 형식에 맞지 않는 필드가 존재합니다", InvalidRequestTypeException.class),
+    DUPLICATE_USER(HttpStatus.CONFLICT, "1001", "Danplay 서비스에 가입되어있는 계정입니다", DuplicateMailException.class),
+    INVALID_MAIL_CODE(HttpStatus.CONFLICT, "1002", "유효하지 않은 인증코드 입니다", InvalidMailCodeException.class),
+    NON_EXIST_MAIL_USER(HttpStatus.NOT_FOUND, "2001", "존재하지 않는 계정입니다", NonExistMailUserException.class),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "2002","비밀번호가 일치하지 않습니다", InvalidPasswordException.class),
+    INVALID_FIND_PASSWORD(HttpStatus.UNAUTHORIZED, "2003", "서버에 저장된 사용자 정보와 일치하지 않습니다", InvalidFindPasswordException.class);
 
+    private final HttpStatus status;
     private final String code;
     private final String message;
     private final Class<? extends Exception> type;

--- a/src/main/java/com/danplay/server/base/exception/ExceptionController.java
+++ b/src/main/java/com/danplay/server/base/exception/ExceptionController.java
@@ -15,7 +15,7 @@ public class ExceptionController {
 
     @ExceptionHandler(DanplayException.class)
     public ResponseEntity<DanplayExceptionDto> ExceptionHandler(DanplayException exception) {
-        return ResponseEntity.badRequest()
+        return ResponseEntity.status(exception.getStatus())
                 .body(new DanplayExceptionDto(exception.getCode(), exception.getMessage()));
     }
 

--- a/src/main/java/com/danplay/server/mail/exception/InvalidMailTypeException.java
+++ b/src/main/java/com/danplay/server/mail/exception/InvalidMailTypeException.java
@@ -1,7 +1,0 @@
-package com.danplay.server.mail.exception;
-
-import com.danplay.server.base.exception.DanplayException;
-
-public class InvalidMailTypeException extends DanplayException {
-
-}

--- a/src/main/java/com/danplay/server/user/application/UserService.java
+++ b/src/main/java/com/danplay/server/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.danplay.server.user.application;
 
 import com.danplay.server.auth.token.TokenInfo;
 import com.danplay.server.mail.application.MailService;
+import com.danplay.server.mail.exception.DuplicateMailException;
 import com.danplay.server.user.exception.InvalidFindPasswordException;
 import com.danplay.server.user.domain.entity.PreferSport;
 import com.danplay.server.user.domain.entity.User;
@@ -33,6 +34,8 @@ public class UserService {
 
     @Transactional
     public UserResponse signUp(SignUpRequest signUpRequest) {
+
+        if (userRepository.existsByMail(signUpRequest.getMail())) throw new DuplicateMailException();
 
         signUpRequest.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
 

--- a/src/main/java/com/danplay/server/user/exception/DuplicateLoginIdException.java
+++ b/src/main/java/com/danplay/server/user/exception/DuplicateLoginIdException.java
@@ -1,6 +1,0 @@
-package com.danplay.server.user.exception;
-
-import com.danplay.server.base.exception.DanplayException;
-
-public class DuplicateLoginIdException extends DanplayException {
-}

--- a/src/main/java/com/danplay/server/user/exception/UserException.java
+++ b/src/main/java/com/danplay/server/user/exception/UserException.java
@@ -1,8 +1,0 @@
-package com.danplay.server.user.exception;
-
-public class UserException extends RuntimeException {
-
-    public UserException(String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
유저 회원가입 API에서,
프론트에서 메일 인증을 통해 중복 확인, 코드까지 확인하고 변경 못하게 비활성화된 메일을 줄 것이라고 생각하여
회원가입 코드에서는 메일 중복 확인을 하지 않았는데- 그래도 혹시 몰라 회원가입에서도 메일 중복 인증을 하게 했습니다.

또한 상태코드 재정의를 완료했습니다.