### PR TITLE
feat: 유저-메일 컨트롤러 상태코드 정의, swagger 버전 변경, jwt 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'io.springfox:springfox-swagger2:2.9.2'
-	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+	implementation "io.springfox:springfox-boot-starter:3.0.0"
+	implementation "io.springfox:springfox-swagger-ui:3.0.0"
 
 	// mapstruct
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'

--- a/src/main/java/com/danplay/server/auth/application/AuthService.java
+++ b/src/main/java/com/danplay/server/auth/application/AuthService.java
@@ -1,0 +1,44 @@
+package com.danplay.server.auth.application;
+
+import com.danplay.server.auth.exception.InvalidAccessToken;
+import com.danplay.server.auth.exception.InvalidRequestToken;
+import com.danplay.server.user.domain.entity.User;
+import com.danplay.server.user.domain.repository.UserRepository;
+import com.danplay.server.user.exception.NonExistMailUserException;
+import com.danplay.server.util.JwtUtil;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+@AllArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public String getTokenByHeader(HttpServletRequest httpServletRequest) {
+        final String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) throw new InvalidRequestToken();
+        System.out.println(authHeader);
+        return authHeader.substring("Bearer ".length());
+    }
+
+    public User getUserByToken(HttpServletRequest httpServletRequest) {
+
+        final String token = getTokenByHeader(httpServletRequest);
+        User user = null;
+        System.out.println(token);
+
+        try {
+            if (jwtUtil.isTokenExpired(token)) throw new InvalidAccessToken();
+
+            user = userRepository.getUserByMail(jwtUtil.getEmailByToken(token)).orElseThrow(NonExistMailUserException::new);
+        } catch (InvalidAccessToken invalidAccessToken) {}
+
+        return user;
+    }
+}

--- a/src/main/java/com/danplay/server/auth/exception/InvalidAccessToken.java
+++ b/src/main/java/com/danplay/server/auth/exception/InvalidAccessToken.java
@@ -1,0 +1,6 @@
+package com.danplay.server.auth.exception;
+
+import com.danplay.server.base.exception.DanplayException;
+
+public class InvalidAccessToken extends DanplayException {
+}

--- a/src/main/java/com/danplay/server/auth/exception/InvalidRequestToken.java
+++ b/src/main/java/com/danplay/server/auth/exception/InvalidRequestToken.java
@@ -1,0 +1,6 @@
+package com.danplay.server.auth.exception;
+
+import com.danplay.server.base.exception.DanplayException;
+
+public class InvalidRequestToken extends DanplayException {
+}

--- a/src/main/java/com/danplay/server/auth/token/TokenInfo.java
+++ b/src/main/java/com/danplay/server/auth/token/TokenInfo.java
@@ -10,7 +10,7 @@ public class TokenInfo {
 
     private Long id;
 
-    private String email;
+    private String mail;
 
     private Authority authority;
 }

--- a/src/main/java/com/danplay/server/base/exception/ExceptionCodeAndDetails.java
+++ b/src/main/java/com/danplay/server/base/exception/ExceptionCodeAndDetails.java
@@ -1,5 +1,7 @@
 package com.danplay.server.base.exception;
 
+import com.danplay.server.auth.exception.InvalidAccessToken;
+import com.danplay.server.auth.exception.InvalidRequestToken;
 import com.danplay.server.mail.exception.DuplicateMailException;
 import com.danplay.server.user.exception.InvalidFindPasswordException;
 import com.danplay.server.mail.exception.InvalidMailCodeException;
@@ -21,7 +23,10 @@ public enum ExceptionCodeAndDetails {
     INVALID_MAIL_CODE(HttpStatus.CONFLICT, "1002", "유효하지 않은 인증코드 입니다", InvalidMailCodeException.class),
     NON_EXIST_MAIL_USER(HttpStatus.NOT_FOUND, "2001", "존재하지 않는 계정입니다", NonExistMailUserException.class),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "2002","비밀번호가 일치하지 않습니다", InvalidPasswordException.class),
-    INVALID_FIND_PASSWORD(HttpStatus.UNAUTHORIZED, "2003", "서버에 저장된 사용자 정보와 일치하지 않습니다", InvalidFindPasswordException.class);
+    INVALID_FIND_PASSWORD(HttpStatus.UNAUTHORIZED, "2003", "서버에 저장된 사용자 정보와 일치하지 않습니다", InvalidFindPasswordException.class),
+    INVALID_REQUEST_TOKEN(HttpStatus.UNAUTHORIZED, "3001", "인증 토큰이 요청 헤더에 존재하지 않습니다", InvalidRequestToken.class),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "3002", "엑세스 토큰이 유효하지 않습니다", InvalidAccessToken.class);
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/danplay/server/config/SwaggerConfig.java
+++ b/src/main/java/com/danplay/server/config/SwaggerConfig.java
@@ -11,21 +11,21 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
+
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .apiInfo(apiInfo())
+        return new Docket(DocumentationType.OAS_30)
                 .select()
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.ant("/api/**"))
-                .build();
+                .build()
+                .apiInfo(apiInfo());
     }
 
-    public ApiInfo apiInfo() {
+    private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-                .title("Danplay")
+                .title("Danplay API Documentation")
                 .version("1.0")
                 .description("Spring Boot Rest API")
                 .build();

--- a/src/main/java/com/danplay/server/mail/presentation/MailController.java
+++ b/src/main/java/com/danplay/server/mail/presentation/MailController.java
@@ -5,6 +5,7 @@ import com.danplay.server.mail.dto.MailCodeRequest;
 import com.danplay.server.mail.dto.MailRequest;
 import com.danplay.server.mail.dto.MailResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,11 +20,13 @@ public class MailController {
 
     @PostMapping("confirm")
     public ResponseEntity<MailResponse> mailConfirm(@Valid @RequestBody MailRequest mailRequest) {
-        return ResponseEntity.ok().body(mailService.sendVerificationMail(mailRequest.getMail()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(mailService.sendVerificationMail(mailRequest.getMail()));
     }
 
     @PostMapping("code")
     public ResponseEntity<MailResponse> mailCodeConfirm(@Valid @RequestBody MailCodeRequest mailCodeRequest) {
-        return ResponseEntity.ok().body(mailService.checkMailCode(mailCodeRequest));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(mailService.checkMailCode(mailCodeRequest));
     }
 }

--- a/src/main/java/com/danplay/server/match/application/MatchService.java
+++ b/src/main/java/com/danplay/server/match/application/MatchService.java
@@ -1,17 +1,23 @@
 package com.danplay.server.match.application;
 
+import com.danplay.server.auth.application.AuthService;
 import com.danplay.server.match.domain.entity.Match;
 import com.danplay.server.match.domain.repository.MatchRepository;
 import com.danplay.server.match.dto.MatchRequest;
 import java.util.List;
+
+import com.danplay.server.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Service
 @RequiredArgsConstructor
 public class MatchService {
 
+	private final AuthService authService;
 	private final MatchRepository matchRepository;
 
 	public void registerMatch(Match match) {
@@ -34,5 +40,21 @@ public class MatchService {
 
 	public void updateMatch(Match match, MatchRequest matchRequest) {
 		match.updateMatch(matchRequest);
+	}
+
+	public void testJWT(HttpServletRequest httpServletRequest) {
+
+		// 회원가입 후, 로그인을 했을 때 나오는 토큰으로 진행
+
+		// -- 테스트 --
+		// 토큰을 넣지 않았을때
+		// 토큰에 노이즈를 넣었을 때
+
+		// 다음을 통해 토큰으로 유저 획득
+		final User user = authService.getUserByToken(httpServletRequest);
+
+		// 유저 출력
+		System.out.println(user.getMail());
+		System.out.println(user.getName());
 	}
 }

--- a/src/main/java/com/danplay/server/match/presentation/MatchController.java
+++ b/src/main/java/com/danplay/server/match/presentation/MatchController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/match")
@@ -57,6 +59,12 @@ public class MatchController {
 		final Match match = matchService.findMatchById(matchId);
 		matchService.updateMatch(match, matchRequest);
 		matchService.registerMatch(match);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PostMapping("/test")
+	public ResponseEntity<HttpStatus> testJWT(HttpServletRequest httpServletRequest) {
+		matchService.testJWT(httpServletRequest);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }

--- a/src/main/java/com/danplay/server/user/application/UserService.java
+++ b/src/main/java/com/danplay/server/user/application/UserService.java
@@ -98,7 +98,7 @@ public class UserService {
         return userResponse;
     }
 
-    private TokenInfo getTokenInfo(User user) { // 이거 JwtUtil로 돌릴지
+    private TokenInfo getTokenInfo(User user) {
         return new TokenInfo(user.getId(), user.getMail(), user.getAuthority());
     }
 

--- a/src/main/java/com/danplay/server/user/presentation/UserController.java
+++ b/src/main/java/com/danplay/server/user/presentation/UserController.java
@@ -3,6 +3,7 @@ package com.danplay.server.user.presentation;
 import com.danplay.server.user.application.UserService;
 import com.danplay.server.user.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,26 +18,19 @@ public class UserController {
 
     @PostMapping("signup")
     public ResponseEntity<UserResponse> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
-        return ResponseEntity.ok().body(userService.signUp(signUpRequest));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(userService.signUp(signUpRequest));
     }
 
     @PostMapping("signin")
     public ResponseEntity<UserResponse> signIn(@RequestBody @Valid SignInRequest signInRequest) {
-        return ResponseEntity.ok().body(userService.signIn(signInRequest));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(userService.signIn(signInRequest));
     }
 
     @PutMapping("find")
     public ResponseEntity<UserResponse> findPassword(@RequestBody @Valid FindPasswordRequest findPasswordRequest) {
-        return ResponseEntity.ok().body(userService.findPassword(findPasswordRequest));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.findPassword(findPasswordRequest));
     }
-
-//    @PutMapping("reset")
-//    public ResponseEntity<UserResponse> resetPassword(@RequestBody @Valid ResetPasswordRequest resetPasswordRequest) {
-//        return ResponseEntity.ok().body(userService.resetPassword(resetPasswordRequest));
-//    }
-//
-//    @PutMapping("reset/prefer")
-//    public ResponseEntity<UserResponse> resetPassword(@RequestBody @Valid ResetPasswordRequest resetPasswordRequest) {
-//        return ResponseEntity.ok().body(userService.resetPassword(resetPasswordRequest));
-//    }
 }

--- a/src/main/java/com/danplay/server/util/JwtUtil.java
+++ b/src/main/java/com/danplay/server/util/JwtUtil.java
@@ -46,9 +46,9 @@ public class JwtUtil implements Serializable {
      * @return String
      */
     public TokenResponse generateToken(TokenInfo tokenInfo) {
-        String accessToken = generateTokenByType(Token.ACCESS_TOKEN, tokenInfo.getId(), tokenInfo.getEmail(),
+        String accessToken = generateTokenByType(Token.ACCESS_TOKEN, tokenInfo.getId(), tokenInfo.getMail(),
             tokenInfo.getAuthority());
-        String refreshToken = generateTokenByType(Token.REFRESH_TOKEN, tokenInfo.getId(), tokenInfo.getEmail(),
+        String refreshToken = generateTokenByType(Token.REFRESH_TOKEN, tokenInfo.getId(), tokenInfo.getMail(),
             tokenInfo.getAuthority());
 
         log.info("accessToken : " + accessToken);
@@ -65,7 +65,7 @@ public class JwtUtil implements Serializable {
      * @return String
      */
     public String generateRefreshToken(TokenInfo tokenInfo){
-        return generateTokenByType(Token.ACCESS_TOKEN, tokenInfo.getId(), tokenInfo.getEmail(),
+        return generateTokenByType(Token.ACCESS_TOKEN, tokenInfo.getId(), tokenInfo.getMail(),
             tokenInfo.getAuthority());
     }
 
@@ -78,17 +78,21 @@ public class JwtUtil implements Serializable {
      * @return String
      */
     public String generateTokenByType(Token tokenType, long userId, String email, Authority authority){
-        Long expirationSeconds = tokenType.equals(Token.ACCESS_TOKEN)? JWT_TOKEN_EXPIRATION : JWT_REFRESH_TOKEN_EXPIRATION;
+        long expirationSeconds = tokenType.equals(Token.ACCESS_TOKEN)? JWT_TOKEN_EXPIRATION : JWT_REFRESH_TOKEN_EXPIRATION;
 
         Map<String, Object> claims = new HashMap<>();
         claims.put(USER_ID_CLAIM, userId);
         claims.put(USER_AUTHORITY_CLAIM, authority);
         claims.put(EMAIL_CLAIM, email);
 
-        return Jwts.builder().setHeaderParam("typ", "JWT")
-            .setClaims(claims).setSubject(JWT_SUBJECT).setIssuedAt(new Date(System.currentTimeMillis()))
-            .setExpiration(new Date(System.currentTimeMillis() + expirationSeconds * 1000))
-            .signWith(SignatureAlgorithm.HS512, JWT_SECRET_KEY).compact();
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims)
+                .setSubject(JWT_SUBJECT)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationSeconds * 1000))
+                .signWith(SignatureAlgorithm.HS512, JWT_SECRET_KEY)
+                .compact();
     }
 
     /**

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "spring.jwt.subject",
+      "type": "java.lang.String",
+      "description": "Description for spring.jwt.subject."
+  }
+] }


### PR DESCRIPTION
1. 유저 컨트롤러 post, get에 대한 상태코드(200, 201)정의
2. swagger 3.0 변경 -> http://localhost:50000/swagger-ui/index.html 로 진입
3. jwt 적용했으나, 현재는 코드 이해의 부족으로 무조건 옳은 토큰만 들어와야함!***
 -> 노이즈가 끼인 토큰이 들어온다면 interal server err 500띄워짐

4. 우선 옳은 jwt가 들어온다고 가정하고 작업해야 할 것 같음
5. 추후 jwt에 대해 수정되어 옳지 못한 케이스일 경우 exception을 통해 제어